### PR TITLE
Remove unused Newtonsoft.Json reference from Ignition.Root

### DIFF
--- a/Ignition.Root/Ignition.Root.csproj
+++ b/Ignition.Root/Ignition.Root.csproj
@@ -69,10 +69,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\_lib\3rdParty\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="SimpleInjector, Version=3.1.5.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.3.1.5\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
This Newtonsoft.Json reference can overwrite Sitecore's Newtonsoft.Json assembly with an incompatible version if Newtonsoft.Json 6.0.0.0 isn't installed in the GAC.
