### PR TITLE
Refactor Agent DataBind Method into Separate Class

### DIFF
--- a/Ignition.Core/Ignition.Core.csproj
+++ b/Ignition.Core/Ignition.Core.csproj
@@ -192,11 +192,13 @@
     <Compile Include="Models\System\IFile.cs" />
     <Compile Include="Models\System\IFolder.cs" />
     <Compile Include="Models\System\IMediaItem.cs" />
+    <Compile Include="Mvc\IViewModelDataBinder.cs" />
     <Compile Include="Mvc\Routing\PublicRouteAttribute.cs" />
     <Compile Include="Mvc\Routing\PublicRouteProvider.cs" />
     <Compile Include="Mvc\SimpleAgent.cs" />
     <Compile Include="Mvc\ViewEngines\ExperienceEditorViewEngine.cs" />
     <Compile Include="Mvc\ViewEngines\FrameworkConventionsViewEngine.cs" />
+    <Compile Include="Mvc\DefaultViewModelDataBinder.cs" />
     <Compile Include="Repositories\CacheItem.cs" />
     <Compile Include="Repositories\ItemContext.cs" />
     <Compile Include="HtmlHelpers\HtmlHelperExtension.cs" />

--- a/Ignition.Core/Installers/CoreInstaller.cs
+++ b/Ignition.Core/Installers/CoreInstaller.cs
@@ -12,6 +12,7 @@ namespace Ignition.Core.Installers
 		{
 			container.Register<ItemContext>(Lifestyle.Scoped);
 			container.Register<IAgentFactory, SimpleInjectorAgentFactory>(Lifestyle.Scoped);
+			container.Register<IViewModelDataBinder, DefaultViewModelDataBinder>(Lifestyle.Scoped);
 			container.Register(typeof(SimpleAgent<>), new[] { ThisAssembly }, Lifestyle.Transient);
 		}
 	}

--- a/Ignition.Core/Mvc/Agent.cs
+++ b/Ignition.Core/Mvc/Agent.cs
@@ -1,15 +1,16 @@
 ﻿using System;
-using System.Linq;
-using Ignition.Core.Attributes;
+using System.ComponentModel.Composition;
 using Ignition.Core.Models.BaseModels;
 using Ignition.Core.Models.Page;
 using Ignition.Core.Repositories;
-using Sitecore.Diagnostics;
 
 namespace Ignition.Core.Mvc
 {
 	public abstract class Agent<TViewModel> where TViewModel : BaseViewModel, new()
 	{
+		[Import]
+		protected IViewModelDataBinder ViewModelDataBinder { get; set; }
+
 		public string ViewPath => ViewModel.ViewPath;
 		public TViewModel ViewModel { get; protected set; }
 		public ItemContext Context { get; private set; }
@@ -24,39 +25,17 @@ namespace Ignition.Core.Mvc
 			Context = context;
 			RenderingParameters = Context.RenderingParameters;
 			Datasource = Context.DatasourceItem;
+
 			ViewModel = new TViewModel
 			{
 				ContextPage = Context.ContextPage,
 				ParentPlaceholderName = Context.PlaceholderName
 			};
-			DataBind();
+			ViewModelDataBinder.DataBind(ViewModel, Datasource);
+
 			AgentParameters = Context.AgentParameters;
 		}
 
 	    public abstract void PopulateModel();
-
-		private void DataBind()
-		{
-            if (Datasource.GetType().GetCustomAttributes(typeof(IgnoreAutomapAttribute), true).Any()) return;
-		    try
-		    {
-		        foreach (var prop in ViewModel.GetType().GetProperties()
-		            .Where(
-		                a =>
-		                    typeof (IModelBase).IsAssignableFrom(a.PropertyType) &&
-		                    !(typeof (IPage).IsAssignableFrom(a.PropertyType) ||
-		                      typeof (IParamsBase).IsAssignableFrom(a.PropertyType)
-		                      || a.GetCustomAttributes(typeof(IgnoreAutomapAttribute), true).Any())))
-		            prop.SetValue(ViewModel, Datasource);
-		    }
-		    catch (ArgumentNullException argumentNullException)
-		    {
-		        Log.Error("Databind Error", argumentNullException, this);
-		    }
-		    catch (Exception ex)
-		    {
-                Log.Error("Databind Error", ex, this);
-            }
-		}
 	}
 }

--- a/Ignition.Core/Mvc/DefaultViewModelDataBinder.cs
+++ b/Ignition.Core/Mvc/DefaultViewModelDataBinder.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using Ignition.Core.Attributes;
+using Ignition.Core.Models.BaseModels;
+using Ignition.Core.Models.Page;
+using Sitecore.Diagnostics;
+
+namespace Ignition.Core.Mvc
+{
+	public class DefaultViewModelDataBinder : IViewModelDataBinder
+	{
+		public void DataBind(BaseViewModel viewModel, IModelBase dataSource)
+		{
+			if (dataSource.GetType().GetCustomAttributes(typeof(IgnoreAutomapAttribute), true).Any()) return;
+
+			try
+			{
+				foreach (var prop in viewModel.GetType().GetProperties()
+					.Where(
+						a => typeof(IModelBase).IsAssignableFrom(a.PropertyType) &&
+							 !(typeof(IPage).IsAssignableFrom(a.PropertyType) ||
+							  typeof(IParamsBase).IsAssignableFrom(a.PropertyType)
+							  || a.GetCustomAttributes(typeof(IgnoreAutomapAttribute), true).Any())))
+					prop.SetValue(viewModel, dataSource);
+			}
+			catch (ArgumentNullException argumentNullException)
+			{
+				Log.Error("Databind Error", argumentNullException, this);
+			}
+			catch (Exception ex)
+			{
+				Log.Error("Databind Error", ex, this);
+			}
+		}
+	}
+}

--- a/Ignition.Core/Mvc/IViewModelDataBinder.cs
+++ b/Ignition.Core/Mvc/IViewModelDataBinder.cs
@@ -1,0 +1,9 @@
+using Ignition.Core.Models.BaseModels;
+
+namespace Ignition.Core.Mvc
+{
+	public interface IViewModelDataBinder
+	{
+		void DataBind(BaseViewModel viewModel, IModelBase dataSource);
+	}
+}


### PR DESCRIPTION
Refactoring `Agent.DataBind()` into a separate class (and interface), `DefaultViewModelDataBinder`. I think this gives a cleaner separation of concerns and makes `Agents` more extensible.
