### PR TITLE
finalized CE mappings

### DIFF
--- a/Ignition.Infrastructure/Pipelines/EditorFormatter.cs
+++ b/Ignition.Infrastructure/Pipelines/EditorFormatter.cs
@@ -40,53 +40,48 @@ namespace Ignition.Infrastructure.Pipelines
 	    {
 		    var itemField = field.ItemField;
 		    var language = Arguments.Language;
-
+		    var customFieldMapping = false;
 		    var s = field.TemplateField.GetTitle(language);
 		    if (string.IsNullOrEmpty(s))
 			    s = field.TemplateField.IgnoreDictionaryTranslations ? itemField.Name : Translate.Text(itemField.Name);
-
-		    if (YmlSettingsReader.TemplateMap.TemplateItem.Any(a => a.TemplateName == s))
-		    {
+		    var template = field.ItemField.Item.TemplateName;
+			var item =
+					YmlSettingsReader.TemplateMap.TemplateItem.FirstOrDefault(a => a.TemplateName == template)?
+						.MapItems.FirstOrDefault(a => a.FieldName == s);
 			    
-		    }
-
-			var toolTip = itemField.ToolTip;
-
-			if (!string.IsNullOrEmpty(toolTip))
+			if (item != null)
 			{
-				var text = Translate.Text(toolTip);
-				if (text.EndsWith(".", StringComparison.InvariantCulture))
-					text = StringUtil.Left(text, text.Length - 1);
-				s = s + " - " + text;
+				s = $"<b>[Ignition-{s}]</b>: <span style=\"font-style: italic\">{item.MapTo}</span>";
+				customFieldMapping = true;
 			}
 
-			var str1 = HttpUtility.HtmlEncode(s);
-			var label =
-				field.ItemField.GetLabel(Arguments.IsAdministrator || Settings.ContentEditor.ShowFieldSharingLabels);
+			var toolTip = itemField.ToolTip;
+		    
+		    if (!string.IsNullOrEmpty(toolTip))
+		    {
+			    var text = Translate.Text(toolTip);
+			    if (text.EndsWith(".", StringComparison.InvariantCulture))
+				    text = StringUtil.Left(text, text.Length - 1);
+			    s = (customFieldMapping && !string.IsNullOrEmpty(item.ShortDescription)) ? $"{s} - <span style=\"font-style: italic\">{item.ShortDescription}</span>" : $"{s} - {text}";
+		    }
 
+			var str1 = customFieldMapping ? s : HttpUtility.HtmlEncode(s);
+
+		    var label = field.ItemField.GetLabel(Arguments.IsAdministrator || Settings.ContentEditor.ShowFieldSharingLabels);
 			if (!string.IsNullOrEmpty(label))
 				str1 = str1 + "<span class=\"scEditorFieldLabelAdministrator\"> [" + label + "]</span>";
-
 			var typeKey = itemField.TypeKey;
-
 			if (!string.IsNullOrEmpty(typeKey) && typeKey != "checkbox")
 				str1 += ":";
-
 			if (readOnly)
 				str1 = "<span class=\"scEditorFieldLabelDisabled\">" + str1 + "</span>";
-
 			var str2 = HttpUtility.HtmlAttributeEncode(itemField.HelpLink);
-
 			if (str2.Length > 0)
 				str1 = "<a class=\"scEditorFieldLabelLink\" href=\"" + str2 + "\" target=\"__help\">" + str1 + "</a>";
-
 			var str3 = string.Empty;
-
 			if (itemField.Description.Length > 0)
 				str3 = " title=\"" + HttpUtility.HtmlAttributeEncode(itemField.Description) + "\"";
-
 			var text1 = "<div class=\"" + "scEditorFieldLabel" + "\"" + str3 + ">" + str1 + "</div>";
-
 			AddLiteralControl(parent, text1);
 		}
 		#endregion

--- a/Ignition.Infrastructure/Pipelines/FieldnameRewriter.cs
+++ b/Ignition.Infrastructure/Pipelines/FieldnameRewriter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Sitecore.Diagnostics;
+﻿using Sitecore.Diagnostics;
 using Sitecore.Shell.Applications.ContentEditor.Pipelines.RenderContentEditor;
 namespace Ignition.Infrastructure.Pipelines
 {
@@ -12,7 +8,6 @@ namespace Ignition.Infrastructure.Pipelines
         {
             Assert.ArgumentNotNull(args, "args");
             var editorFormatter = new EditorFormatter(args);
-			//var writer = new YmlSettingsReader();
             editorFormatter.RenderSections(args.Parent, args.Sections, args.ReadOnly);
         }
     }

--- a/Ignition.Infrastructure/Pipelines/MapItem.cs
+++ b/Ignition.Infrastructure/Pipelines/MapItem.cs
@@ -4,5 +4,6 @@
 	{
 		public string FieldName { get; set; }
 		public string MapTo { get; set; }
+		public string ShortDescription { get; set; }
 	}
 }

--- a/Ignition.Root/App_Config/FieldSettings.yml
+++ b/Ignition.Root/App_Config/FieldSettings.yml
@@ -1,14 +1,15 @@
 ﻿---
 TemplateItem: 
+  - TemplateName: IgnitionPage
+    MapItems:
+    - FieldName: PageTitle
+      MapTo: Page Title
+      ShortDescription: The modified title of the page that appears in the browser
+    - FieldName: PageDescription
+      MapTo: Meta Description
   - TemplateName: Metadata
     MapItems:
-    - FieldName: PasgeTitle
-      MapTo: Title
-    - FieldName: Subtitle
-      MapTo: Subheading
-  - TemplateName: CallToAction2
-    MapItems:
-    - FieldName: Heading
+    - FieldName: PageTitle
       MapTo: Title
     - FieldName: Subtitle
       MapTo: Subheading

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Base Classes/Metadata/Metadata/PageDescription.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Base Classes/Metadata/Metadata/PageDescription.yml
@@ -14,6 +14,9 @@ SharedFields:
 Languages:
 - Language: en
   Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: "Generally used with the Meta-description."
   - ID: "b5e02ad9-d56f-4c41-a065-a133db87bdeb"
     Hint: __Display name
     Value: Page Description

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Abstract/Content/Abstract.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Abstract/Content/Abstract.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
-  Value: Rich Text
+  Value: 
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/BackgroundImage/Content/BackgroundImage.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/BackgroundImage/Content/BackgroundImage.yml
@@ -13,6 +13,10 @@ SharedFields:
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: 
   Versions:
   - Version: 1
     Fields:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/BackgroundImageAlternate/Content/BackgroundImageAlternate.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/BackgroundImageAlternate/Content/BackgroundImageAlternate.yml
@@ -7,12 +7,16 @@ DB: master
 SharedFields:
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
-  Value: Image
+  Value: 
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: 
   Versions:
   - Version: 1
     Fields:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/DateField1/Content/DateField1.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/DateField1/Content/DateField1.yml
@@ -13,6 +13,10 @@ SharedFields:
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: 
   Versions:
   - Version: 1
     Fields:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Image/Content/Image.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Image/Content/Image.yml
@@ -13,6 +13,10 @@ SharedFields:
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: "[Ignition:Image] - An Image used in relation to the control."
   Versions:
   - Version: 1
     Fields:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Image2/Content/Image2.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Image2/Content/Image2.yml
@@ -13,6 +13,10 @@ SharedFields:
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: 
   Versions:
   - Version: 1
     Fields:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Logo.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Logo.yml
@@ -14,7 +14,7 @@ SharedFields:
   Value: "{4C3CDC24-1610-4808-92A3-A221768AE3B2}"
 - ID: "f7d48a55-2158-4f02-9356-756654404f73"
   Hint: __Standard values
-  Value: "{B9D58671-49AC-4D65-9A56-36ED867B83F8}"
+  Value: 
 Languages:
 - Language: en
   Versions:

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Logo/Content/Logo.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/Logo/Content/Logo.yml
@@ -1,13 +1,13 @@
 ﻿---
-ID: "b1ac24a8-141d-4cec-8009-38606f8bc160"
-Parent: "80cae42a-39fb-4dcd-af13-48099bef13d9"
+ID: "51451715-a87f-441f-acf5-6e469f48d12d"
+Parent: "a133afe1-eb84-4d8c-bea1-200285361be3"
 Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
-Path: /sitecore/templates/Ignition/Fields/Content/DateField2/Content/DateField2
+Path: /sitecore/templates/Ignition/Fields/Content/Logo/Content/Logo
 DB: master
 SharedFields:
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
-  Value: Datetime
+  Value: Image
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 100
@@ -22,4 +22,4 @@ Languages:
     Fields:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
-      Value: 20160222T151602Z
+      Value: 20160808T170336Z

--- a/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/PublicationDate/Content/PublicationDate.yml
+++ b/Ignition.Unicorn/Unicorn/Ignition Framework Core/Templates/Ignition/Fields/Content/PublicationDate/Content/PublicationDate.yml
@@ -13,6 +13,10 @@ SharedFields:
   Value: 100
 Languages:
 - Language: en
+  Fields:
+  - ID: "9541e67d-ce8c-4225-803d-33f7f29f09ef"
+    Hint: __Short description
+    Value: 
   Versions:
   - Version: 1
     Fields:


### PR DESCRIPTION
New Feature: By editing /App_Config/FieldSettings.yml you can now change both the name and description shown in the Content Editor for technically any field. Specifically this is used to change inherited fields so that when a name isn't intuitive it can be changed in the CE. When this occurs, the old fieldname still appears in bold:
[Ignition-RichText1] NewFieldName
the NewFieldname is italicized also noting that it is changed.
For any of these, if a fieldname has been changed, the Short Description can be changed as well. If it is, it's italicized as well. If it's not, it remains in normal typeface.
